### PR TITLE
Fix ROS 2 controller bounds and shutdown

### DIFF
--- a/ROS2/R5_ws/src/ARX_R5_ros2_V7/arx_r5_controller/src/R5Controller.cpp
+++ b/ROS2/R5_ws/src/ARX_R5_ros2_V7/arx_r5_controller/src/R5Controller.cpp
@@ -6,7 +6,6 @@
 namespace arx::r5 {
 R5Controller::R5Controller() : Node("r5_controller_node") {
   RCLCPP_INFO(this->get_logger(), "机械臂开始初始化...");
-  rclcpp::on_shutdown(std::bind(&R5Controller::cleanup, this));
   std::string arm_control_type = this->declare_parameter("arm_control_type", "normal");
   std::string package_name = "arx_r5_controller";
   std::string package_share_dir = ament_index_cpp::get_package_share_directory(package_name);
@@ -113,17 +112,17 @@ void R5Controller::PubState() {
   message.end_pos = result;
 
   std::vector<double> joint_pos_vector = interfaces_ptr_->getJointPositons();
-  for (int i = 0; i <= 7; i++) {
+  for (std::size_t i = 0; i < message.joint_pos.size() && i < joint_pos_vector.size(); ++i) {
     message.joint_pos[i] = joint_pos_vector[i];
   }
 
   std::vector<double> joint_velocities_vector = interfaces_ptr_->getJointVelocities();
-  for (int i = 0; i <= 7; i++) {
+  for (std::size_t i = 0; i < message.joint_vel.size() && i < joint_velocities_vector.size(); ++i) {
     message.joint_vel[i] = joint_velocities_vector[i];
   }
 
   std::vector<double> joint_current_vector = interfaces_ptr_->getJointCurrent();
-  for (int i = 0; i < 7; i++) {
+  for (std::size_t i = 0; i < message.joint_cur.size() && i < joint_current_vector.size(); ++i) {
     message.joint_cur[i] = joint_current_vector[i];
   }
   // 发布消息
@@ -194,15 +193,15 @@ void R5Controller::VrPubState() {
 
   msg.end_pos = result;
 
-  for (int i = 0; i <= 7; i++) {
+  for (std::size_t i = 0; i < msg.joint_pos.size() && i < joint_pos_vector.size(); ++i) {
     msg.joint_pos[i] = joint_pos_vector[i];
   }
 
-  for (int i = 0; i <= 7; i++) {
+  for (std::size_t i = 0; i < msg.joint_vel.size() && i < joint_velocities_vector.size(); ++i) {
     msg.joint_vel[i] = joint_velocities_vector[i];
   }
 
-  for (int i = 0; i < 7; i++) {
+  for (std::size_t i = 0; i < msg.joint_cur.size() && i < joint_current_vector.size(); ++i) {
     msg.joint_cur[i] = joint_current_vector[i];
   }
   // 发布消息


### PR DESCRIPTION
## Summary

- Fix out-of-bounds writes when publishing the seven-element joint position, velocity, and current arrays.
- Bound copies by both the ROS message array size and the SDK vector size.
- Avoid releasing the hardware interface from a global shutdown callback while the 1 kHz state timer may still be active.

## Problem

`RobotStatus.msg` defines seven-element joint arrays, but the controller loops previously used `i <= 7`, which writes index 7 and invokes undefined behavior.

The controller also registered an `on_shutdown` callback that immediately reset `interfaces_ptr_`. During a Ctrl+C shutdown this could race with `PubState()`, which accesses the same pointer every millisecond. On the tested system, the motor and CAN cleanup ran, but the process then exited with code `-11`.

Relying on normal node/member destruction stops executor callbacks before releasing the hardware interface. After this change, the receiver thread and CAN socket terminate cleanly and the process exits normally.

## Validation

- Ubuntu 24.04, ROS 2 Jazzy, x86_64
- Real ARX R5 connected through `can1`
- `colcon build --symlink-install --packages-select arx_r5_controller`
- `/arm_status` received at approximately 1000 Hz
- SocketCAN reported zero bus errors and dropped frames
- Repeated launch and Ctrl+C shutdown completed cleanly

The official documentation targets ROS 2 Humble; maintainers should also verify the lifecycle change on Humble.